### PR TITLE
feat: thread through observedAttributes from the react component

### DIFF
--- a/src/dev/index.js
+++ b/src/dev/index.js
@@ -39,7 +39,13 @@ module.exports = {
       }
     }
 
+    const observedAttributes = app.type.observedAttributes;
+
     const proto = class extends HTMLElement {
+      static get observedAttributes() {
+        return observedAttributes || [];
+      }
+
       connectedCallback() {
         const webComponentInstance = this;
         let mountPoint = webComponentInstance;


### PR DESCRIPTION
mimics the webcomponent static get observedAttributes interface on the react component, and threads through that value to the web component, since that's needed to be declared for attribute observation...

i noticed that there are a few of these PRs already, but mine takes a slightly different tack. We do need `observedAttributes` for this to work correctly